### PR TITLE
Add email confirmation via Resend

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,15 @@
+# Slack App Integration
+SLACK_BOT_TOKEN=
+SLACK_CHANNEL_ID=
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+SLACK_VERIFICATION_TOKEN=
+
+# Email sending via Resend
+RESEND_API_KEY=
+DEMO_REQUEST_EMAIL_TO=info@zenpulsar.com
+DEMO_REQUEST_EMAIL_FROM=no-reply@zenpulsar.com
+
+# Site URL
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A modern Next.js application for ZENPULSAR's commodities intelligence platform, 
 - **Component Library**: shadcn/ui components with Radix UI primitives
 - **MDX Support**: Rich content management with Markdown and JSX
 - **Form Integration**: Slack App API integration for reliable lead capture
+- **Email Notifications**: Automatic confirmation emails via Resend
 - **Performance Optimized**: Image optimization, font optimization, and lazy loading
 - **SEO Ready**: Comprehensive metadata and Open Graph support
 - **Responsive Design**: Mobile-first design with smooth animations
@@ -54,10 +55,12 @@ A modern Next.js application for ZENPULSAR's commodities intelligence platform, 
    SLACK_SIGNING_SECRET=your-signing-secret
    SLACK_VERIFICATION_TOKEN=your-verification-token
    
-   # Other services
-   RESEND_API_KEY=your_resend_api_key
-   NEXT_PUBLIC_SITE_URL=https://zenpulsar.com
-   ```
+  # Other services
+  RESEND_API_KEY=your_resend_api_key
+  DEMO_REQUEST_EMAIL_TO=info@zenpulsar.com
+  DEMO_REQUEST_EMAIL_FROM=no-reply@zenpulsar.com
+  NEXT_PUBLIC_SITE_URL=https://zenpulsar.com
+  ```
 
 4. **Run the development server**
    ```bash
@@ -263,6 +266,8 @@ SLACK_SIGNING_SECRET=your-signing-secret
 
 # Other services
 RESEND_API_KEY=your_resend_key
+DEMO_REQUEST_EMAIL_TO=info@zenpulsar.com
+DEMO_REQUEST_EMAIL_FROM=no-reply@zenpulsar.com
 NEXT_PUBLIC_SITE_URL=https://your-domain.com
 NODE_ENV=production
 ```

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
 		"build:cf": "opennextjs-cloudflare build",
 		"build:full": "pnpm build && pnpm build:cf",
 		"start": "next start",
-		"lint": "next lint",
-		"deploy": "pnpm build:full && wrangler deploy",
+                "lint": "next lint",
+                "test": "tsx tests/email.smoke.tsx",
+                "deploy": "pnpm build:full && wrangler deploy",
 		"preview": "pnpm build:full && wrangler dev",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
 	},
@@ -46,6 +47,7 @@
 		"prettier": "^3.6.2",
 		"prettier-plugin-tailwindcss": "^0.6.14",
 		"tailwindcss": "^4",
+		"tsx": "^4.20.3",
 		"tw-animate-css": "^1.3.5",
 		"typescript": "^5",
 		"wrangler": "^4.25.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.11
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       tw-animate-css:
         specifier: ^1.3.5
         version: 1.3.5
@@ -4563,6 +4566,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tw-animate-css@1.3.5:
     resolution: {integrity: sha512-t3u+0YNoloIhj1mMXs779P6MO9q3p3mvGn4k1n3nJPqJw/glZcuijG2qTSN4z4mgNRfW5ZC3aXJFLwDtiipZXA==}
@@ -10598,6 +10606,13 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.4
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tw-animate-css@1.3.5: {}
 

--- a/src/app/api/demo/route.ts
+++ b/src/app/api/demo/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sendToSlack, createDemoRequestMessage } from "@/lib/slack";
+import { sendDemoRequestEmail } from "@/lib/email";
 import { DemoFormData } from "@/lib/types";
 
 export async function POST(request: NextRequest) {
@@ -19,6 +20,9 @@ export async function POST(request: NextRequest) {
 
     // Send to Slack
     await sendToSlack(slackMessage);
+
+    // Send confirmation email
+    await sendDemoRequestEmail(body);
 
     return NextResponse.json(
       { message: "Demo request sent successfully" },

--- a/src/emails/demo-request.tsx
+++ b/src/emails/demo-request.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { DemoFormData } from "@/lib/types";
+
+export default function DemoRequestEmail({ firstName, lastName, email, company, message }: DemoFormData) {
+  return (
+    <div>
+      <h1>New Demo Request</h1>
+      <p><strong>Name:</strong> {firstName} {lastName}</p>
+      <p><strong>Email:</strong> {email}</p>
+      <p><strong>Company:</strong> {company}</p>
+      {message && <p><strong>Message:</strong> {message}</p>}
+    </div>
+  );
+}

--- a/src/lib/email.tsx
+++ b/src/lib/email.tsx
@@ -1,0 +1,25 @@
+import { Resend } from "resend";
+import { render } from "@react-email/render";
+import DemoRequestEmail from "@/emails/demo-request";
+import { DemoFormData } from "./types";
+import { siteConfig } from "./constants";
+
+const resend = new Resend(process.env.RESEND_API_KEY || "");
+
+export async function sendDemoRequestEmail(data: DemoFormData): Promise<void> {
+  if (!process.env.RESEND_API_KEY) {
+    throw new Error("RESEND_API_KEY environment variable is not set");
+  }
+
+  const to = process.env.DEMO_REQUEST_EMAIL_TO || siteConfig.links.email;
+  const from = process.env.DEMO_REQUEST_EMAIL_FROM || siteConfig.links.email;
+
+  const html = render(<DemoRequestEmail {...data} />);
+
+  await resend.emails.send({
+    from,
+    to,
+    subject: "New Demo Request - ZENPULSAR",
+    html,
+  });
+}

--- a/tests/email.smoke.tsx
+++ b/tests/email.smoke.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import DemoRequestEmail from "../src/emails/demo-request";
+
+async function main() {
+  const html = renderToStaticMarkup(
+    <DemoRequestEmail
+      firstName="Test"
+      lastName="User"
+      email="test@example.com"
+      company="ACME"
+      message="Hello"
+    />
+  );
+
+  if (!html.includes("Test User")) {
+    console.error("Email template render failed");
+    process.exit(1);
+  }
+  console.log("Email smoke test passed");
+}
+
+main();


### PR DESCRIPTION
## Summary
- send demo-request emails using Resend
- document email environment variables
- add example env file
- include smoke test for email template

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_687fd11ffb20832d879913feb007711a